### PR TITLE
Refer model

### DIFF
--- a/data_format.adoc
+++ b/data_format.adoc
@@ -227,40 +227,16 @@ This is needed to enable dynamic simulators to model the human-WR system.
 
 === Human anthropometric measures file
 
-**Description**: This file shall contain all the anthropometric measurements presented in Table 1 (Winter, 2009) and Figure 3.
+**Description**: This file shall contain all the anthropometric measurements of the human body segment, as detailed in <<model.adoc#Human body segment, model document>>.
 
 **Name of the file**: subject_N_anthropometry, where N = subject’s number.
 Use appropriate leading zeros for R and N to ensure proper ordering of files.
 
 **File format**: .yaml
 
-**File structure**: Set of lines containing key: value where the key is provided in Table 2.
+**File structure**: Set of lines containing key: value where the key is provided in table <<model.adoc#table:body_segment>>.
 
-.List of body segments and joints considered in our kinematic model proposed.
-[options="header"]
-|================
-| Group | Segments | Delimiting Joints | key label
-.4+| **Upper limb**
-  | Hand | wrist axis / 2nd knuckle middle finger | hand
-  | Forearm | elbow axis / ulnar styloid | forearm
-  | Upper Arm | glenhumeral axis / elbow axis | upper_arm
-  | Shoulder| sternoclaviar joint / glenhumeral axis | shoulder
-.5+| **Lower limb**
-  | Foot | lateral malleolus / head 2nd metatarsal | foot
-  | Shank | femoral condyles / medial malleolus | shank
-  | Thigh | greater trochanter / femoral condyles | thigh
-  | Pelvis | L4-L5 / greater trochanter | pelvis
-  | Pelvis width| From hip to hip | pelwis_w
-2+| **Head** | C7-T1 & first rip / ear canal | head
-2+| **Trunk** | C7-T1 / T12-L1 & diaphragm | trunk
-2+| **abdomen** | T12-L1 / L4-L5 | abdomen
-|================
-
-Units: Meters
-
-[[fig:df_segment_label]]
-.Segments Labels
-image::img/df_segment_label.png[align=center, title-align=center]
+**Units**: Meters
 
 === Humanoid anthropometric measures file
 

--- a/data_format.adoc
+++ b/data_format.adoc
@@ -307,7 +307,7 @@ We will work together with you to create the required data file type.
 
 === Joint angles file
 
-**Description**: This file shall contain the time-series of all measured joint angles, expressed in YXZ Cardan Angles, as defined in the “Angle Definition” section.
+**Description**: This file shall contain the time-series of all measured joint angles, expressed in YXZ Cardan Angles, as defined in the <<model.adoc#sec_angles, Angle Definition>> section.
 
 **filename root**: `jointAngles`  where N = subject’s number and R = run number.
 Use appropriate leading zeros for R and N to ensure proper ordering of files.
@@ -323,6 +323,7 @@ Use appropriate leading zeros for R and N to ensure proper ordering of files.
 | `sec` | `deg` | `deg` | `deg` | `deg` | `deg` | `deg` | ... | ... | ...
 |================
 
+Joint labels should refer to the names provided within the <<model.adoc#fig:df_joint_center_label, human model document>>.
 
 === Joint torques file
 
@@ -341,6 +342,8 @@ Use appropriate leading zeros for R and N to ensure proper ordering of files.
 | `sec` | `N.m` | `N.m` | `N.m` | `N.m` | `N.m` | `N.m` | ... | ... | ...
 |================
 
+Joint labels should refer to the names provided within the <<model.adoc#fig:df_joint_center_label, human model document>>.
+
 === Joint center 3D trajectories file
 
 **Description**: This file shall contain all the measured trajectories of the joints.
@@ -358,11 +361,7 @@ Use appropriate leading zeros for R and N to ensure proper ordering of files.
 | `sec` | `m` | `m` | `m` | `m` | `m` | `m` | ... | ... | ...
 |================
 
-Possible labels are listed on Figure <<fig:df_joint_center_label>>.
-
-[[fig:df_joint_center_label]]
-.Labels of Joints centers
-image::img/df_joint_center_label.png[align=center, title-align=center]
+Joint labels should refer to the names provided within the <<model.adoc#fig:df_joint_center_label, human model document>>.
 
 === Body Center of Mass 3D trajectory
 

--- a/data_format.adoc
+++ b/data_format.adoc
@@ -234,7 +234,7 @@ Use appropriate leading zeros for R and N to ensure proper ordering of files.
 
 **File format**: .yaml
 
-**File structure**: Set of lines containing key: value where the key is provided in table <<model.adoc#table:body_segment>>.
+**File structure**: Set of lines containing key: value where the key is provided in the <<model.adoc#table:body_segment, body segment table>>.
 
 **Units**: Meters
 

--- a/data_format.adoc
+++ b/data_format.adoc
@@ -227,7 +227,7 @@ This is needed to enable dynamic simulators to model the human-WR system.
 
 === Human anthropometric measures file
 
-**Description**: This file shall contain all the anthropometric measurements of the human body segment, as detailed in <<model.adoc#Human body segment, model document>>.
+**Description**: This file shall contain all the anthropometric measurements of the human body segment, as detailed in the <<model.adoc#sec_hbs, model document>>.
 
 **Name of the file**: subject_N_anthropometry, where N = subject’s number.
 Use appropriate leading zeros for R and N to ensure proper ordering of files.

--- a/data_format.adoc
+++ b/data_format.adoc
@@ -234,7 +234,7 @@ Use appropriate leading zeros for R and N to ensure proper ordering of files.
 
 **File format**: .yaml
 
-**File structure**: Set of lines containing key: value where the key is provided in the <<model.adoc#table:body_segment, body segment table>>.
+**File structure**: Set of lines containing key: value where the key is provided in the <<model.adoc#table_body_segment, body segment table>>.
 
 **Units**: Meters
 

--- a/data_format.adoc
+++ b/data_format.adoc
@@ -323,7 +323,7 @@ Use appropriate leading zeros for R and N to ensure proper ordering of files.
 | `sec` | `deg` | `deg` | `deg` | `deg` | `deg` | `deg` | ... | ... | ...
 |================
 
-Joint labels should refer to the names provided within the <<model.adoc#fig:df_joint_center_label, human model document>>.
+Joint labels should refer to the names provided within the <<model.adoc#fig_joint_center_label, human model document>>.
 
 === Joint torques file
 
@@ -342,7 +342,7 @@ Joint labels should refer to the names provided within the <<model.adoc#fig:df_j
 | `sec` | `N.m` | `N.m` | `N.m` | `N.m` | `N.m` | `N.m` | ... | ... | ...
 |================
 
-Joint labels should refer to the names provided within the <<model.adoc#fig:df_joint_center_label, human model document>>.
+Joint labels should refer to the names provided within the <<model.adoc#fig_joint_center_label, human model document>>.
 
 === Joint center 3D trajectories file
 

--- a/data_format.adoc
+++ b/data_format.adoc
@@ -361,7 +361,7 @@ Joint labels should refer to the names provided within the <<model.adoc#fig:df_j
 | `sec` | `m` | `m` | `m` | `m` | `m` | `m` | ... | ... | ...
 |================
 
-Joint labels should refer to the names provided within the <<model.adoc#fig:df_joint_center_label, human model document>>.
+Joint labels should refer to the names provided within the <<model.adoc#fig_joint_center_label, human model document>>.
 
 === Body Center of Mass 3D trajectory
 

--- a/model.adoc
+++ b/model.adoc
@@ -11,7 +11,7 @@ Concepts and label described here are then used and referenced in the <<data_for
 
 == Joint centers
 
-[[fig:df_joint_center_label]]
+[[fig_df_joint_center_label]]
 .Labels of Joints centers
 image::img/df_joint_center_label.png[align=center, title-align=center]
 

--- a/model.adoc
+++ b/model.adoc
@@ -11,7 +11,7 @@ Concepts and label described here are then used and referenced in the <<data_for
 
 == Joint centers
 
-[[fig_df_joint_center_label]]
+[[fig_joint_center_label]]
 .Labels of Joints centers
 image::img/df_joint_center_label.png[align=center, title-align=center]
 

--- a/model.adoc
+++ b/model.adoc
@@ -21,7 +21,6 @@ Each body segment is a single body with multiple dimensions, inertial and mass p
 
 Each segment has a key label assigned, for bilateral bodies use the prefix "_r" or "_l" to differentiate between right and left bodies. E.g. "r_hand"
 
-
 [[table_body_segment]]
 .List of body segments and joints considered in our kinematic model proposed.
 [options="header"]
@@ -55,8 +54,8 @@ Each segment has a key label assigned, for bilateral bodies use the prefix "_r" 
 .Segments Labels
 image::img/df_segment_label.png[align=center, title-align=center]
 
+[[sec_angles]]
 == Angles definition
-
 
 All the angle definitions here presented are based on the Plug-in Gait model from Vicon.
 Joint angles are represented by the YXZ Cardan angles derived by comparing the relative orientations of the proximal (parent) and distal (child) segments around each joint (see Figure 4).

--- a/model.adoc
+++ b/model.adoc
@@ -16,6 +16,7 @@ Concepts and label described here are then used and referenced in the <<data_for
 image::img/df_joint_center_label.png[align=center, title-align=center]
 
 == Human body segment
+[[sec_hbs]]
 Each body segment is a single body with multiple dimensions, inertial and mass properties. Each body segment is delimited by one or more joints. Depending on the availability and need for properties different models could be constructed by merging adjacent segments or approximating them to null-mass bodiesfootnote:[e.g. the "shoulder" segment is useful to compute degrees of freedom, but its mass property is difficult to assess and not generally available, so it could be used with a null mass or merged with the trunk].
 
 Each segment has a key label assigned, for bilateral bodies use the prefix "_r" or "_l" to differentiate between right and left bodies. E.g. "r_hand"

--- a/model.adoc
+++ b/model.adoc
@@ -21,6 +21,7 @@ Each body segment is a single body with multiple dimensions, inertial and mass p
 Each segment has a key label assigned, for bilateral bodies use the prefix "_r" or "_l" to differentiate between right and left bodies. E.g. "r_hand"
 
 .List of body segments and joints considered in our kinematic model proposed.
+[[table:body_segment]]
 [options="header"]
 |================
 | Group | Segments | Delimiting Joints | key label

--- a/model.adoc
+++ b/model.adoc
@@ -21,8 +21,9 @@ Each body segment is a single body with multiple dimensions, inertial and mass p
 
 Each segment has a key label assigned, for bilateral bodies use the prefix "_r" or "_l" to differentiate between right and left bodies. E.g. "r_hand"
 
+
+[[table_body_segment]]
 .List of body segments and joints considered in our kinematic model proposed.
-[[table:body_segment]]
 [options="header"]
 |================
 | Group | Segments | Delimiting Joints | key label


### PR DESCRIPTION
Related to [this comment](https://github.com/aremazeilles/eurobench_documentation/pull/25#issuecomment-689344512)
Simplified the data_format file, referring to the model file that contains sement anf joint names and figures.
